### PR TITLE
swaggerをdocker-composeで実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-# ローカル環境での PostgreSQL 接続および動作確認
+## ローカル環境での PostgreSQL 接続および動作確認
 
 ローカルで PostgreSQL と繋げられるように設定済み。動作確認も完了していますが、現時点では自動でテーブルの作成は行えません。詳細は以下をご参照ください。なお、質問がある場合は中安に問い合わせてください。
-
-## 動作確認手順
 
 ### 前提条件
 
@@ -55,3 +53,18 @@
 4. **Go サイドで確認**  
    ブラウザで以下にアクセス：
    http://localhost:8080/users
+
+## API 仕様
+
+API 仕様は SwaggerUI を利用して閲覧します。
+
+```
+$ docker compose up swagger-ui
+```
+
+を実行することでローカルの Docker 上に SwaggerUI サーバが起動します。<br>
+<br>
+SwaggerUI サーバ起動後以下の URL から SwaggerUI へアクセスすることができます。
+
+SwaggerUI: <http://localhost:8000/> <br>
+定義ファイル: `./api-document.yaml`<br>

--- a/api-document.yaml
+++ b/api-document.yaml
@@ -1,0 +1,30 @@
+openapi: "3.0.2"
+info:
+  title: "Sample API"
+  version: "1.0.0"
+servers:
+  - url: http://localhost:8080/
+paths:
+  /users:
+    get:
+      summary: "Get list of users"
+      operationId: "getUsers"
+      responses:
+        "200":
+          description: "A list of users"
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  users:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        name:
+                          type: string
+                        status:
+                          type: string

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,11 @@
+version: "3"
+
+services:
+  swagger-ui:
+    image: swaggerapi/swagger-ui:latest
+    environment:
+      SWAGGER_JSON: /api/api-document.yaml
+    volumes:
+      - ./api-document.yaml:/api/api-document.yaml:ro
+    ports:
+      - "127.0.0.1:8000:8080"

--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,14 @@ go 1.23.1
 
 require (
 	github.com/labstack/echo v3.3.10+incompatible
+	github.com/lib/pq v1.10.9
+)
+
+require (
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
+	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
 	github.com/labstack/echo/v4 v4.12.0 // indirect
 	github.com/labstack/gommon v0.4.2 // indirect
-	github.com/lib/pq v1.10.9
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
@@ -15,4 +20,5 @@ require (
 	golang.org/x/net v0.24.0 // indirect
 	golang.org/x/sys v0.19.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
+	golang.org/x/time v0.5.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,7 @@
+github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
+github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
+github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/labstack/echo v3.3.10+incompatible h1:pGRcYk231ExFAyoAjAfD85kQzRJCRI8bbnE7CX5OEgg=
 github.com/labstack/echo v3.3.10+incompatible/go.mod h1:0INS7j/VjnFxD4E2wkz67b8cVwCLbBmJyDaka6Cmk1s=
 github.com/labstack/echo/v4 v4.12.0 h1:IKpw49IMryVB2p1a4dzwlhP1O2Tf2E0Ir/450lH+kI0=
@@ -25,3 +29,5 @@ golang.org/x/sys v0.19.0 h1:q5f1RH2jigJ1MoAWp2KTp3gm5zAGFUTarQZ5U386+4o=
 golang.org/x/sys v0.19.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
 golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
+golang.org/x/time v0.5.0 h1:o7cqy6amK/52YcAKIPlM3a+Fpj35zvRj2TP+e1xFSfk=
+golang.org/x/time v0.5.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=

--- a/morpet.go
+++ b/morpet.go
@@ -1,10 +1,11 @@
 package main
 
 import (
-	"morpet-backend/routes"
 	"morpet-backend/config"
+	"morpet-backend/routes"
 
 	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
 )
 
 func main() {
@@ -13,11 +14,16 @@ func main() {
 	defer config.CloseDB()
 
 	e := echo.New()
+	// swaggerだけ許可されるようにしている
+	e.Use(middleware.CORSWithConfig(middleware.CORSConfig{
+		AllowOrigins: []string{"http://localhost:8000"},
+		AllowMethods: []string{echo.GET, echo.POST, echo.PUT, echo.DELETE},
+	}))
 	// e.GET("/", func(c echo.Context) error {
 	// 	return c.String(http.StatusOK, "Hello, World!")
 	// })
 	// e.GET("/users", handlers.GetUsers)
 	routes.InitRoutes(e)
-	
+
 	e.Logger.Fatal(e.Start(":8080"))
 }


### PR DESCRIPTION
api-document.yamlにswaggerの内容を追記していて、
docker-compose.yamlを立ち上げると、swaggerにアクセスできるようになっている

swagger上でexecuteボタンを押してDBの中身が帰ってくれば成功！